### PR TITLE
Add automated deployment of docker image to google container registry

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,9 @@
-version: 2
+version: 2.1
+
+# See https://circleci.com/orbs/registry/orb/circleci/gcp-gcr
+orbs:
+    gcp-gcr: circleci/gcp-gcr@0.6.1
+
 jobs:
   build:
     docker:
@@ -29,6 +34,13 @@ jobs:
 
 workflows:
   version: 2
-  build:
+  build-and-deploy:
     jobs:
       - build
+      - gcp-gcr/build-and-push-image:
+          requires:
+              - build
+          image: pensieve
+          filters:
+              branches:
+                  only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 # See https://circleci.com/orbs/registry/orb/circleci/gcp-gcr
 orbs:
-    gcp-gcr: circleci/gcp-gcr@0.6.1
+  gcp-gcr: circleci/gcp-gcr@0.6.1
 
 jobs:
   build:
@@ -42,4 +42,5 @@ workflows:
           image: pensieve
           filters:
             branches:
-              only: master
+              only:
+                master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,8 +38,8 @@ workflows:
       - build
       - gcp-gcr/build-and-push-image:
           requires:
-              - build
+            - build
           image: pensieve
           filters:
-              branches:
-                  only: master
+            branches:
+              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,6 @@ jobs:
         key: *cache_key
 
 workflows:
-  version: 2
   build-and-deploy:
     jobs:
       - build


### PR DESCRIPTION
This PR adds an automated deploy step to CI that builds the docker image and uploads it to the GCP project's container registry. Modeled using the deployment step in mozilla/forecasting

I added all the environment vars required to the project already so hopefully when this is merged in we'll see an auto-deploy..