### PR TITLE
Add logging, fix bustage

### DIFF
--- a/pensieve/analysis.py
+++ b/pensieve/analysis.py
@@ -76,7 +76,7 @@ class Analysis:
 
         return current_time_limits
 
-    def run(self, experiment: experimenter.Experiment, current_date: datetime):
+    def run(self, experiment: experimenter.Experiment, current_date: datetime, dry_run: bool):
         """
         Run analysis using mozanalysis for a specific experiment.
         """
@@ -110,5 +110,8 @@ class Analysis:
 
         if self.bq_context is None:
             self.bq_context = BigQueryContext(project_id=self.project, dataset_id=self.dataset)
+
+        if dry_run:
+            return
 
         self.bq_context.run_query(sql, res_table_name)

--- a/pensieve/analysis.py
+++ b/pensieve/analysis.py
@@ -41,9 +41,11 @@ class Analysis:
         prior_date_str = (current_date - timedelta(days=1)).strftime("%Y-%m-%d")
         current_date_str = current_date.strftime("%Y-%m-%d")
 
-        dates_enrollment = 0
-        if experiment.proposed_enrollment:
-            dates_enrollment = experiment.proposed_enrollment + 1
+        if not experiment.proposed_enrollment:
+            self.logger.info("Skipping %s; no enrollment period", experiment.slug)
+            return None
+
+        dates_enrollment = experiment.proposed_enrollment + 1
 
         if experiment.start_date is None:
             return None

--- a/pensieve/tests/test_analysis.py
+++ b/pensieve/tests/test_analysis.py
@@ -1,5 +1,6 @@
 import datetime as dt
 from datetime import timedelta
+import json
 import pytz
 import pytest
 
@@ -41,3 +42,41 @@ def test_get_timelimits_if_ready(experiments):
 
     date = dt.datetime(2019, 12, 1, tzinfo=pytz.utc) + timedelta(2)
     assert analysis._get_timelimits_if_ready(experiments[0], date) is None
+
+
+def test_regression_20200320():
+    experiment_json = r"""
+        {
+          "experiment_url": "https://experimenter.services.mozilla.com/experiments/impact-of-level-2-etp-on-a-custom-distribution/",
+          "type": "pref",
+          "name": "Impact of Level 2 ETP on a Custom Distribution",
+          "slug": "impact-of-level-2-etp-on-a-custom-distribution",
+          "public_name": "Impact of Level 2 ETP",
+          "status": "Live",
+          "start_date": 1580169600000,
+          "end_date": 1595721600000,
+          "proposed_start_date": 1580169600000,
+          "proposed_enrollment": null,
+          "proposed_duration": 180,
+          "normandy_slug": "pref-impact-of-level-2-etp-on-a-custom-distribution-release-72-80-bug-1607493",
+          "normandy_id": 906,
+          "other_normandy_ids": [],
+          "variants": [
+            {
+              "description": "",
+              "is_control": true,
+              "name": "treatment",
+              "ratio": 100,
+              "slug": "treatment",
+              "value": "true",
+              "addon_release_url": null,
+              "preferences": []
+            }
+          ]
+        }
+    """  # noqa
+    experiment = Experiment.from_dict(json.loads(experiment_json))
+    analysis = Analysis("test", "test")
+    analysis.run(
+        experiment, current_date=dt.datetime(2020, 3, 19), dry_run=True,
+    )

--- a/script/run_experiment_analysis
+++ b/script/run_experiment_analysis
@@ -5,7 +5,7 @@ Fetches experiments from Experimenter and runs analysis on active experiments.
 """
 
 from argparse import ArgumentParser
-from datetime import datetime, timedelta
+from datetime import datetime
 import logging
 import os
 import sys

--- a/script/run_experiment_analysis
+++ b/script/run_experiment_analysis
@@ -30,6 +30,11 @@ parser.add_argument(
     help="Last date for which data should be analysed",
     type=lambda s: datetime.strptime(s, "%Y-%m-%d"),
 )
+parser.add_argument(
+    "--dry_run",
+    help="Don't publish any changes to BigQuery",
+    action="store_true",
+)
 
 
 def format_date(date):
@@ -53,7 +58,7 @@ def main():
     analysis = Analysis(args.project_id, args.dataset_id)
 
     for experiment in active_experiments.experiments:
-        analysis.run(experiment, date)
+        analysis.run(experiment, date, dry_run=args.dry_run)
 
 
 if __name__ == "__main__":

--- a/script/run_experiment_analysis
+++ b/script/run_experiment_analysis
@@ -6,6 +6,7 @@ Fetches experiments from Experimenter and runs analysis on active experiments.
 
 from argparse import ArgumentParser
 from datetime import datetime, timedelta
+import logging
 import os
 import sys
 import pytz
@@ -43,6 +44,10 @@ def format_date(date):
 
 
 def main():
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(levelname)s:%(asctime)s:%(name)s:%(message)s",
+    )
     args = parser.parse_args()
 
     # fetch experiments that are still active


### PR DESCRIPTION
The fix is to skip experiments defined without an enrollment period. I think mozanalysis should handle this case more politely (cf https://github.com/mozilla/mozanalysis/issues/74) but I think that trying to analyze experiments without an enrollment period probably doesn't make any sense in this model of analysis.

This PR adds a --dry_run flag and some logging. (How dry should dry be? We could ask BigQuery to validate the query for us -- right now I'm just returning early and avoiding the BQ call.)