### PR TITLE
MetricsConfiguration is just an enum-typed dict

### DIFF
--- a/pensieve/__init__.py
+++ b/pensieve/__init__.py
@@ -1,0 +1,12 @@
+import enum
+
+
+class AnalysisPeriod(enum.Enum):
+    DAY = "day"
+    WEEK = "week"
+    OVERALL = "overall"
+
+    @property
+    def adjective(self) -> str:
+        d = {"day": "daily", "week": "weekly", "overall": "overall"}
+        return d[self.value]

--- a/pensieve/analysis.py
+++ b/pensieve/analysis.py
@@ -5,7 +5,6 @@ from textwrap import dedent
 from typing import Optional
 
 import attr
-import enum
 import google.cloud.bigquery.client
 import google.cloud.bigquery.dataset
 import google.cloud.bigquery.job
@@ -14,18 +13,8 @@ import mozanalysis
 from mozanalysis.experiment import TimeLimits
 from mozanalysis.utils import add_days
 
+from . import AnalysisPeriod
 from . import config
-
-
-class AnalysisPeriod(enum.Enum):
-    DAY = "day"
-    WEEK = "week"
-    OVERALL = "overall"
-
-    @property
-    def adjective(self) -> str:
-        d = {"day": "daily", "week": "weekly", "overall": "overall"}
-        return d[self.value]
 
 
 @attr.s(auto_attribs=True)
@@ -180,7 +169,7 @@ class Analysis:
             res_table_name = self._table_name(period.value, window)
 
             sql = exp.build_query(
-                getattr(self.config.metrics, period.adjective),
+                self.config.metrics[period],
                 last_window_limits,
                 "normandy",
                 self.config.experiment.enrollment_query,

--- a/pensieve/analysis.py
+++ b/pensieve/analysis.py
@@ -142,7 +142,7 @@ class Analysis:
             self.logger.info("Skipping %s; no start_date", self.config.experiment.slug)
             return
 
-        for period in AnalysisPeriod:
+        for period in self.config.metrics:
             time_limits = self._get_timelimits_if_ready(period, current_date)
             if time_limits is None:
                 self.logger.info(

--- a/pensieve/config.py
+++ b/pensieve/config.py
@@ -34,19 +34,19 @@ import pensieve.experimenter
 # TODO: these should be objects that pair a metric with a default statistical treatment.
 DEFAULT_METRICS = {
     "desktop": {
-        "daily": {mozanalysis.metrics.desktop.unenroll},
-        "weekly": {
+        "daily": [mozanalysis.metrics.desktop.unenroll],
+        "weekly": [
             mozanalysis.metrics.desktop.active_hours,
             mozanalysis.metrics.desktop.uri_count,
             mozanalysis.metrics.desktop.ad_clicks,
             mozanalysis.metrics.desktop.search_count,
-        },
-        "overall": {
+        ],
+        "overall": [
             mozanalysis.metrics.desktop.active_hours,
             mozanalysis.metrics.desktop.uri_count,
             mozanalysis.metrics.desktop.ad_clicks,
             mozanalysis.metrics.desktop.search_count,
-        },
+        ],
     }
 }
 

--- a/pensieve/config.py
+++ b/pensieve/config.py
@@ -19,7 +19,7 @@ which produce concrete mozanalysis classes when resolved.
 """
 
 from types import ModuleType
-from typing import Any, Dict, Iterable, List, Optional, Set, Type, TypeVar
+from typing import Any, Dict, Iterable, List, Optional, Type, TypeVar
 
 import attr
 import cattr
@@ -27,6 +27,7 @@ import jinja2
 import mozanalysis.metrics
 import mozanalysis.metrics.desktop
 
+from pensieve.analysis import AnalysisPeriod
 import pensieve.experimenter
 
 
@@ -173,13 +174,7 @@ class MetricDefinition:
         )
 
 
-@attr.s(auto_attribs=True)
-class MetricsConfiguration:
-    """Contains the metrics configured for each analysis window of an experiment."""
-
-    daily: Set[mozanalysis.metrics.Metric]
-    weekly: Set[mozanalysis.metrics.Metric]
-    overall: Set[mozanalysis.metrics.Metric]
+MetricsConfigurationType = Dict[AnalysisPeriod, List[mozanalysis.metrics.Metric]]
 
 
 @attr.s(auto_attribs=True)
@@ -195,7 +190,7 @@ class MetricsSpec:
     @classmethod
     def from_dict(cls, d: dict) -> "MetricsSpec":
         params: Dict[str, Any] = {}
-        known_keys = ("daily", "weekly", "overall")
+        known_keys = {f.name for f in attr.fields(cls)}
         for k in known_keys:
             v = d.get(k, [])
             if not isinstance(v, list):
@@ -211,21 +206,24 @@ class MetricsSpec:
     @staticmethod
     def _merge_metrics(
         user: Iterable[mozanalysis.metrics.Metric], default: Iterable[mozanalysis.metrics.Metric]
-    ) -> Set[mozanalysis.metrics.Metric]:
-        result = set(user)
+    ) -> List[mozanalysis.metrics.Metric]:
+        result = list(user)
         user_names = {m.name for m in user}
         for m in default:
             if m.name not in user_names:
-                result.add(m)
+                result.append(m)
         return result
 
-    def resolve(self, spec: "AnalysisSpec") -> MetricsConfiguration:
+    def resolve(self, spec: "AnalysisSpec") -> MetricsConfigurationType:
         def merge(k: str):
             return self._merge_metrics(
                 {ref.resolve(spec) for ref in getattr(self, k)}, DEFAULT_METRICS["desktop"][k]
             )
 
-        return MetricsConfiguration(merge("daily"), merge("weekly"), merge("overall"))
+        result = {}
+        for period in AnalysisPeriod:
+            result[period] = merge(period.adjective)
+        return result
 
 
 _converter.register_structure_hook(MetricsSpec, lambda obj, _type: MetricsSpec.from_dict(obj))
@@ -281,7 +279,7 @@ class AnalysisConfiguration:
     """
 
     experiment: ExperimentConfiguration
-    metrics: MetricsConfiguration
+    metrics: MetricsConfigurationType
 
 
 @attr.s(auto_attribs=True)

--- a/pensieve/tests/integration/test_analysis_integration.py
+++ b/pensieve/tests/integration/test_analysis_integration.py
@@ -12,6 +12,7 @@ import string
 from mozanalysis.metrics import Metric, DataSource, agg_sum
 from google.api_core.exceptions import NotFound
 
+from pensieve import AnalysisPeriod
 from pensieve.analysis import Analysis
 from pensieve.config import AnalysisSpec
 from pensieve.experimenter import Experiment, Variant
@@ -112,9 +113,7 @@ class TestAnalysisIntegration:
             select_expr=agg_sum("active_hours_sum"),
         )
 
-        config.metrics.daily = []
-        config.metrics.weekly = [test_active_hours]
-        config.metrics.overall = []
+        config.metrics = {AnalysisPeriod.WEEK: [test_active_hours]}
 
         analysis = Analysis(self.project_id, self.test_dataset, config)
 

--- a/pensieve/tests/test_config.py
+++ b/pensieve/tests/test_config.py
@@ -3,7 +3,7 @@ from textwrap import dedent
 import toml
 import pytest
 
-from pensieve import config
+from pensieve import AnalysisPeriod, config
 
 
 class TestAnalysisSpec:
@@ -13,7 +13,7 @@ class TestAnalysisSpec:
         cfg = spec.resolve(experiments[0])
         assert isinstance(cfg, config.AnalysisConfiguration)
         # There should be some default metrics
-        assert len(cfg.metrics.weekly)
+        assert len(cfg.metrics[AnalysisPeriod.WEEK])
 
     def test_scalar_metrics_throws_exception(self):
         config_str = dedent(
@@ -38,7 +38,7 @@ class TestAnalysisSpec:
         )
         spec = config.AnalysisSpec.from_dict(toml.loads(config_str))
         cfg = spec.resolve(experiments[0])
-        metric = [m for m in cfg.metrics.weekly if m.name == "my_cool_metric"][0]
+        metric = [m for m in cfg.metrics[AnalysisPeriod.WEEK] if m.name == "my_cool_metric"][0]
         assert "agg_histogram_mean" not in metric.select_expr
         assert "json_extract_histogram" in metric.select_expr
 
@@ -51,7 +51,9 @@ class TestAnalysisSpec:
         )
         spec = config.AnalysisSpec.from_dict(toml.loads(config_str))
         cfg = spec.resolve(experiments[0])
-        assert len([m for m in cfg.metrics.weekly if m.name == "view_about_logins"]) == 1
+        assert (
+            len([m for m in cfg.metrics[AnalysisPeriod.WEEK] if m.name == "view_about_logins"]) == 1
+        )
 
     def test_duplicate_metrics_are_okay(self, experiments):
         config_str = dedent(
@@ -62,7 +64,7 @@ class TestAnalysisSpec:
         )
         spec = config.AnalysisSpec.from_dict(toml.loads(config_str))
         cfg = spec.resolve(experiments[0])
-        assert len([m for m in cfg.metrics.weekly if m.name == "unenroll"]) == 1
+        assert len([m for m in cfg.metrics[AnalysisPeriod.WEEK] if m.name == "unenroll"]) == 1
 
     def test_data_source_definition(self, experiments):
         config_str = dedent(
@@ -81,7 +83,7 @@ class TestAnalysisSpec:
         )
         spec = config.AnalysisSpec.from_dict(toml.loads(config_str))
         cfg = spec.resolve(experiments[0])
-        spam = [m for m in cfg.metrics.weekly if m.name == "spam"][0]
+        spam = [m for m in cfg.metrics[AnalysisPeriod.WEEK] if m.name == "spam"][0]
         assert spam.data_source.name == "eggs"
         assert "camelot" in spam.data_source.from_expr
         assert "client_info" in spam.data_source.client_id_column
@@ -100,7 +102,7 @@ class TestAnalysisSpec:
         )
         spec = config.AnalysisSpec.from_dict(toml.loads(config_str))
         cfg = spec.resolve(experiments[0])
-        stock = [m for m in cfg.metrics.weekly if m.name == "active_hours"][0]
+        stock = [m for m in cfg.metrics[AnalysisPeriod.WEEK] if m.name == "active_hours"][0]
 
         config_str = dedent(
             """
@@ -114,7 +116,7 @@ class TestAnalysisSpec:
         )
         spec = config.AnalysisSpec.from_dict(toml.loads(config_str))
         cfg = spec.resolve(experiments[0])
-        custom = [m for m in cfg.metrics.weekly if m.name == "active_hours"][0]
+        custom = [m for m in cfg.metrics[AnalysisPeriod.WEEK] if m.name == "active_hours"][0]
 
         assert stock != custom
         assert custom.select_expr == "spam"


### PR DESCRIPTION
We're iterating over the keys often enough that we might as well just make it official instead of calling getattr() so much.

I don't feel really strongly about this; I don't love that it makes the Spec/Configuration story a little weaker but I'm pleased that it's straightforward to specify and feels a little less hacky.

I also don't really like using Sets here anymore, because they imply that adding a Metric is safe; it's possible to have non-identical Metrics with the same `name`, so a Set is not guaranteed not to have collisions, and testing whether a metric is already in the set is probably not useful.

Up to you!