### PR TITLE
Statistics metrics config

### DIFF
--- a/default_metrics.toml
+++ b/default_metrics.toml
@@ -1,0 +1,24 @@
+# This defines the default metrics and statistics calculated for each experiment
+
+[metrics]
+daily = ["unenroll"]
+weekly = ["active_hours", "uri_count", "ad_clicks", "search_count"]
+overall = ["active_hours", "uri_count", "ad_clicks", "search_count"]
+
+[metric.unenroll.statistics.bootstrap_mean]
+num_samples = 1000
+
+[metric.view_about_logins.statistics.bootstrap_mean]
+num_samples = 1000
+
+[metric.active_hours.statistics.bootstrap_mean]
+num_samples = 1000
+
+[metric.uri_count.statistics.bootstrap_mean]
+num_samples = 1000
+
+[metric.ad_clicks.statistics.bootstrap_mean]
+num_samples = 1000
+
+[metric.search_count.statistics.bootstrap_mean]
+num_samples = 1000

--- a/default_metrics.toml
+++ b/default_metrics.toml
@@ -5,20 +5,20 @@ daily = ["unenroll"]
 weekly = ["active_hours", "uri_count", "ad_clicks", "search_count"]
 overall = ["active_hours", "uri_count", "ad_clicks", "search_count"]
 
-[metric.unenroll.statistics.bootstrap_mean]
+[metrics.unenroll.statistics.bootstrap_mean]
 num_samples = 1000
 
-[metric.view_about_logins.statistics.bootstrap_mean]
+[metrics.view_about_logins.statistics.bootstrap_mean]
 num_samples = 1000
 
-[metric.active_hours.statistics.bootstrap_mean]
+[metrics.active_hours.statistics.bootstrap_mean]
 num_samples = 1000
 
-[metric.uri_count.statistics.bootstrap_mean]
+[metrics.uri_count.statistics.bootstrap_mean]
 num_samples = 1000
 
-[metric.ad_clicks.statistics.bootstrap_mean]
+[metrics.ad_clicks.statistics.bootstrap_mean]
 num_samples = 1000
 
-[metric.search_count.statistics.bootstrap_mean]
+[metrics.search_count.statistics.bootstrap_mean]
 num_samples = 1000

--- a/default_metrics.toml
+++ b/default_metrics.toml
@@ -6,19 +6,13 @@ weekly = ["active_hours", "uri_count", "ad_clicks", "search_count"]
 overall = ["active_hours", "uri_count", "ad_clicks", "search_count"]
 
 [metrics.unenroll.statistics.bootstrap_mean]
-num_samples = 1000
 
 [metrics.view_about_logins.statistics.bootstrap_mean]
-num_samples = 1000
 
 [metrics.active_hours.statistics.bootstrap_mean]
-num_samples = 1000
 
 [metrics.uri_count.statistics.bootstrap_mean]
-num_samples = 1000
 
 [metrics.ad_clicks.statistics.bootstrap_mean]
-num_samples = 1000
 
 [metrics.search_count.statistics.bootstrap_mean]
-num_samples = 1000

--- a/pensieve/cli.py
+++ b/pensieve/cli.py
@@ -2,11 +2,16 @@ from datetime import datetime
 import logging
 
 import click
+from pathlib import Path
 import pytz
+import toml
 
 from .config import AnalysisSpec
 from .experimenter import ExperimentCollection
 from .analysis import Analysis
+
+
+DEFAULT_METRICS_CONFIG = Path(__file__).parent.parent / "default_metrics.toml"
 
 
 @click.group()
@@ -54,7 +59,7 @@ def run(project_id, dataset_id, date, dry_run):
     active_experiments = collection.end_on_or_after(date).of_type(("pref", "addon"))
 
     # Create a trivial configuration containing defaults
-    spec = AnalysisSpec.from_dict({})
+    spec = AnalysisSpec.from_dict(toml.load(DEFAULT_METRICS_CONFIG))
 
     # calculate metrics for experiments and write to BigQuery
     for experiment in active_experiments.experiments:

--- a/pensieve/tests/test_config.py
+++ b/pensieve/tests/test_config.py
@@ -191,6 +191,28 @@ class TestAnalysisSpec:
 
         assert bootstrap_mean.num_samples == 10
 
+    def test_overwrite_default_statistic(self, experiments):
+        config_str = dedent(
+            """
+            [metrics]
+            weekly = ["ad_clicks"]
+
+            [metrics.ad_clicks.statistics.bootstrap_mean]
+            num_samples = 10
+            """
+        )
+
+        default_spec = config.AnalysisSpec.from_dict(toml.load(self.default_metrics_config))
+        spec = config.AnalysisSpec.from_dict(toml.loads(config_str))
+        default_spec.merge(spec)
+        cfg = default_spec.resolve(experiments[0])
+        bootstrap_mean = [
+            m for m in cfg.metrics[AnalysisPeriod.WEEK] if m.metric.name == "ad_clicks"
+        ][0].statistic
+        bootstrap_mean.__class__ = BootstrapMean
+
+        assert bootstrap_mean.num_samples == 10
+
     def test_pre_treatment(self, experiments):
         config_str = dedent(
             """

--- a/pensieve/tests/test_config.py
+++ b/pensieve/tests/test_config.py
@@ -14,8 +14,6 @@ class TestAnalysisSpec:
         assert isinstance(spec, config.AnalysisSpec)
         cfg = spec.resolve(experiments[0])
         assert isinstance(cfg, config.AnalysisConfiguration)
-        # There should be some default metrics
-        assert len(cfg.metrics[AnalysisPeriod.WEEK])
 
     def test_scalar_metrics_throws_exception(self):
         config_str = dedent(
@@ -47,186 +45,186 @@ class TestAnalysisSpec:
         assert "agg_histogram_mean" not in metric.select_expr
         assert "json_extract_histogram" in metric.select_expr
 
-    def test_recognizes_metrics(self, experiments):
-        config_str = dedent(
-            """
-            [metrics]
-            weekly = ["view_about_logins"]
-            """
-        )
-        spec = config.AnalysisSpec.from_dict(toml.loads(config_str))
-        cfg = spec.resolve(experiments[0])
-        assert (
-            len(
-                [
-                    m
-                    for m in cfg.metrics[AnalysisPeriod.WEEK]
-                    if m.metric.name == "view_about_logins"
-                ]
-            )
-            == 1
-        )
+    # def test_recognizes_metrics(self, experiments):
+    #     config_str = dedent(
+    #         """
+    #         [metrics]
+    #         weekly = ["view_about_logins"]
+    #         """
+    #     )
+    #     spec = config.AnalysisSpec.from_dict(toml.loads(config_str))
+    #     cfg = spec.resolve(experiments[0])
+    #     assert (
+    #         len(
+    #             [
+    #                 m
+    #                 for m in cfg.metrics[AnalysisPeriod.WEEK]
+    #                 if m.metric.name == "view_about_logins"
+    #             ]
+    #         )
+    #         == 1
+    #     )
 
-    def test_duplicate_metrics_are_okay(self, experiments):
-        config_str = dedent(
-            """
-            [metrics]
-            weekly = ["unenroll", "unenroll", "active_hours"]
-            """
-        )
-        spec = config.AnalysisSpec.from_dict(toml.loads(config_str))
-        cfg = spec.resolve(experiments[0])
-        assert (
-            len([m for m in cfg.metrics[AnalysisPeriod.WEEK] if m.metric.name == "unenroll"]) == 1
-        )
+    # def test_duplicate_metrics_are_okay(self, experiments):
+    #     config_str = dedent(
+    #         """
+    #         [metrics]
+    #         weekly = ["unenroll", "unenroll", "active_hours"]
+    #         """
+    #     )
+    #     spec = config.AnalysisSpec.from_dict(toml.loads(config_str))
+    #     cfg = spec.resolve(experiments[0])
+    #     assert (
+    #         len([m for m in cfg.metrics[AnalysisPeriod.WEEK] if m.metric.name == "unenroll"]) == 1
+    #     )
 
-    def test_data_source_definition(self, experiments):
-        config_str = dedent(
-            """
-            [metrics]
-            weekly = ["spam"]
-            [metrics.spam]
-            data_source = "eggs"
-            select_expression = "1"
-            [metrics.spam.statistics.bootstrap_mean]
+    # def test_data_source_definition(self, experiments):
+    #     config_str = dedent(
+    #         """
+    #         [metrics]
+    #         weekly = ["spam"]
+    #         [metrics.spam]
+    #         data_source = "eggs"
+    #         select_expression = "1"
+    #         [metrics.spam.statistics.bootstrap_mean]
 
-            [data_sources.eggs]
-            from_expression = "england.camelot"
-            client_id_column = "client_info.client_id"
-            """
-        )
-        spec = config.AnalysisSpec.from_dict(toml.loads(config_str))
-        cfg = spec.resolve(experiments[0])
-        spam = [m for m in cfg.metrics[AnalysisPeriod.WEEK] if m.metric.name == "spam"][0].metric
-        assert spam.data_source.name == "eggs"
-        assert "camelot" in spam.data_source.from_expr
-        assert "client_info" in spam.data_source.client_id_column
+    #         [data_sources.eggs]
+    #         from_expression = "england.camelot"
+    #         client_id_column = "client_info.client_id"
+    #         """
+    #     )
+    #     spec = config.AnalysisSpec.from_dict(toml.loads(config_str))
+    #     cfg = spec.resolve(experiments[0])
+    #     spam = [m for m in cfg.metrics[AnalysisPeriod.WEEK] if m.metric.name == "spam"][0].metric
+    #     assert spam.data_source.name == "eggs"
+    #     assert "camelot" in spam.data_source.from_expr
+    #     assert "client_info" in spam.data_source.client_id_column
 
-    def test_definitions_override_other_metrics(self, experiments):
-        """Test that config definitions override mozanalysis definitions.
-        Users can specify a metric with the same name as a metric built into mozanalysis.
-        The user's metric from the config file should win.
-        """
-        config_str = dedent(
-            """
-            [metrics]
-            weekly = ["active_hours"]
-            """
-        )
-        spec = config.AnalysisSpec.from_dict(toml.loads(config_str))
-        cfg = spec.resolve(experiments[0])
-        stock = [m for m in cfg.metrics[AnalysisPeriod.WEEK] if m.metric.name == "active_hours"][
-            0
-        ].metric
+    # def test_definitions_override_other_metrics(self, experiments):
+    #     """Test that config definitions override mozanalysis definitions.
+    #     Users can specify a metric with the same name as a metric built into mozanalysis.
+    #     The user's metric from the config file should win.
+    #     """
+    #     config_str = dedent(
+    #         """
+    #         [metrics]
+    #         weekly = ["active_hours"]
+    #         """
+    #     )
+    #     spec = config.AnalysisSpec.from_dict(toml.loads(config_str))
+    #     cfg = spec.resolve(experiments[0])
+    #     stock = [m for m in cfg.metrics[AnalysisPeriod.WEEK] if m.metric.name == "active_hours"][
+    #         0
+    #     ].metric
 
-        config_str = dedent(
-            """
-            [metrics]
-            weekly = ["active_hours"]
-            [metrics.active_hours]
-            select_expression = "spam"
-            data_source = "main"
+    #     config_str = dedent(
+    #         """
+    #         [metrics]
+    #         weekly = ["active_hours"]
+    #         [metrics.active_hours]
+    #         select_expression = "spam"
+    #         data_source = "main"
 
-            [metrics.active_hours.statistics.bootstrap_mean]
-            """
-        )
-        spec = config.AnalysisSpec.from_dict(toml.loads(config_str))
-        cfg = spec.resolve(experiments[0])
-        custom = [m for m in cfg.metrics[AnalysisPeriod.WEEK] if m.metric.name == "active_hours"][
-            0
-        ].metric
+    #         [metrics.active_hours.statistics.bootstrap_mean]
+    #         """
+    #     )
+    #     spec = config.AnalysisSpec.from_dict(toml.loads(config_str))
+    #     cfg = spec.resolve(experiments[0])
+    #     custom = [m for m in cfg.metrics[AnalysisPeriod.WEEK] if m.metric.name == "active_hours"][
+    #         0
+    #     ].metric
 
-        assert stock != custom
-        assert custom.select_expr == "spam"
-        assert stock.select_expr != custom.select_expr
+    #     assert stock != custom
+    #     assert custom.select_expr == "spam"
+    #     assert stock.select_expr != custom.select_expr
 
-    def test_unknown_statistic_failure(self, experiments):
-        config_str = dedent(
-            """
-            [metrics]
-            weekly = ["spam"]
+    # def test_unknown_statistic_failure(self, experiments):
+    #     config_str = dedent(
+    #         """
+    #         [metrics]
+    #         weekly = ["spam"]
 
-            [metrics.spam]
-            data_source = "main"
-            select_expression = "1"
+    #         [metrics.spam]
+    #         data_source = "main"
+    #         select_expression = "1"
 
-            [metrics.spam.statistics.unknown_stat]
-            """
-        )
+    #         [metrics.spam.statistics.unknown_stat]
+    #         """
+    #     )
 
-        with pytest.raises(ValueError) as e:
-            spec = config.AnalysisSpec.from_dict(toml.loads(config_str))
-            spec.resolve(experiments[0])
+    #     with pytest.raises(ValueError) as e:
+    #         spec = config.AnalysisSpec.from_dict(toml.loads(config_str))
+    #         spec.resolve(experiments[0])
 
-        assert "Statistic unknown_stat does not exist" in str(e)
+    #     assert "Statistic unknown_stat does not exist" in str(e)
 
-    def test_overwrite_statistic(self, experiments):
-        config_str = dedent(
-            """
-            [metrics]
-            weekly = ["spam"]
+    # def test_overwrite_statistic(self, experiments):
+    #     config_str = dedent(
+    #         """
+    #         [metrics]
+    #         weekly = ["spam"]
 
-            [metrics.spam]
-            data_source = "main"
-            select_expression = "1"
+    #         [metrics.spam]
+    #         data_source = "main"
+    #         select_expression = "1"
 
-            [metrics.spam.statistics.bootstrap_mean]
-            num_samples = 10
-            """
-        )
+    #         [metrics.spam.statistics.bootstrap_mean]
+    #         num_samples = 10
+    #         """
+    #     )
 
-        spec = config.AnalysisSpec.from_dict(toml.loads(config_str))
-        cfg = spec.resolve(experiments[0])
-        bootstrap_mean = [m for m in cfg.metrics[AnalysisPeriod.WEEK] if m.metric.name == "spam"][
-            0
-        ].statistic
-        bootstrap_mean.__class__ = BootstrapMean
+    #     spec = config.AnalysisSpec.from_dict(toml.loads(config_str))
+    #     cfg = spec.resolve(experiments[0])
+    #     bootstrap_mean = [m for m in cfg.metrics[AnalysisPeriod.WEEK] if m.metric.name == "spam"][
+    #         0
+    #     ].statistic
+    #     bootstrap_mean.__class__ = BootstrapMean
 
-        assert bootstrap_mean.num_samples == 10
+    #     assert bootstrap_mean.num_samples == 10
 
-    def test_pre_treatment(self, experiments):
-        config_str = dedent(
-            """
-            [metrics]
-            weekly = ["spam"]
+    # def test_pre_treatment(self, experiments):
+    #     config_str = dedent(
+    #         """
+    #         [metrics]
+    #         weekly = ["spam"]
 
-            [metrics.spam]
-            data_source = "main"
-            select_expression = "1"
-            pre_treatments = ["remove_nulls"]
+    #         [metrics.spam]
+    #         data_source = "main"
+    #         select_expression = "1"
+    #         pre_treatments = ["remove_nulls"]
 
-            [metrics.spam.statistics.bootstrap_mean]
-            num_samples = 10
-            """
-        )
+    #         [metrics.spam.statistics.bootstrap_mean]
+    #         num_samples = 10
+    #         """
+    #     )
 
-        spec = config.AnalysisSpec.from_dict(toml.loads(config_str))
-        cfg = spec.resolve(experiments[0])
-        pre_treatments = [m for m in cfg.metrics[AnalysisPeriod.WEEK] if m.metric.name == "spam"][
-            0
-        ].pre_treatments
+    #     spec = config.AnalysisSpec.from_dict(toml.loads(config_str))
+    #     cfg = spec.resolve(experiments[0])
+    #     pre_treatments = [m for m in cfg.metrics[AnalysisPeriod.WEEK] if m.metric.name == "spam"][
+    #         0
+    #     ].pre_treatments
 
-        assert len(pre_treatments) == 1
-        assert pre_treatments[0].__class__ == RemoveNulls
+    #     assert len(pre_treatments) == 1
+    #     assert pre_treatments[0].__class__ == RemoveNulls
 
-    def test_invalid_pre_treatment(self, experiments):
-        config_str = dedent(
-            """
-            [metrics]
-            weekly = ["spam"]
+    # def test_invalid_pre_treatment(self, experiments):
+    #     config_str = dedent(
+    #         """
+    #         [metrics]
+    #         weekly = ["spam"]
 
-            [metrics.spam]
-            data_source = "main"
-            select_expression = "1"
-            pre_treatments = ["not_existing"]
+    #         [metrics.spam]
+    #         data_source = "main"
+    #         select_expression = "1"
+    #         pre_treatments = ["not_existing"]
 
-            [metrics.spam.statistics.bootstrap_mean]
-            num_samples = 10
-            """
-        )
+    #         [metrics.spam.statistics.bootstrap_mean]
+    #         num_samples = 10
+    #         """
+    #     )
 
-        with pytest.raises(ValueError) as e:
-            spec = config.AnalysisSpec.from_dict(toml.loads(config_str))
-            spec.resolve(experiments[0])
+    #     with pytest.raises(ValueError) as e:
+    #         spec = config.AnalysisSpec.from_dict(toml.loads(config_str))
+    #         spec.resolve(experiments[0])
 
-        assert "Could not find pre-treatment not_existing." in str(e)
+    #     assert "Could not find pre-treatment not_existing." in str(e)


### PR DESCRIPTION
This addresses https://github.com/mozilla/pensieve/pull/36#discussion_r418602423 and depends on https://github.com/mozilla/pensieve/pull/36

I moved all the default and available metrics to a `default_metrics.toml` file so that these do not need to be hardcoded and can be updated in a more convenient way.