### PR TITLE
Facilitate (re)running previous analyses for an experiment

### DIFF
--- a/pensieve/cli.py
+++ b/pensieve/cli.py
@@ -95,3 +95,27 @@ def run(project_id, dataset_id, start_date, end_date, experiment_slug, dry_run):
 
         for date in date_range(start_date, end_date):
             Analysis(project_id, dataset_id, config).run(date, dry_run=dry_run)
+
+
+@click.option(
+    "--experiment_slug",
+    "--experiment-slug",
+    help="Normandy slug of the experiment to rerun analysis for",
+    required=True,
+)
+@click.option(
+    "--project_id", "--project-id", default="moz-fx-data-experiments", help="Project to write to"
+)
+@click.option("--dataset_id", "--dataset-id", default="mozanalysis", help="Dataset to write to")
+@click.option("--dry_run/--no_dry_run", help="Don't publish any changes to BigQuery")
+def rerun(project_id, dataset_id, experiment_slug, dry_run):
+    """Rerun previous analyses for a specific experiment."""
+    collection = ExperimentCollection.from_experimenter()
+
+    experiments = collection.with_slug(experiment_slug)
+
+    if len(experiments.experiments) == 0:
+        logging.warn(f"No experiment with slug {experiment_slug} found.")
+
+    experiment = experiments.experiments[0]
+    run(project_id, dataset_id, experiment.start_date, None, experiment_slug, dry_run)

--- a/pensieve/cli.py
+++ b/pensieve/cli.py
@@ -25,10 +25,12 @@ def format_date(date):
     """Returns the current date with UTC timezone and time set to 00:00:00."""
     return datetime.combine(date, datetime.min.time()).replace(tzinfo=pytz.utc)
 
+
 def date_range(start_date, end_date):
     """Generator for a range of dates."""
-    for n in range(int ((end_date - start_date).days)):
+    for n in range(int((end_date - start_date).days) + 1):
         yield start_date + timedelta(n)
+
 
 class ClickDate(click.ParamType):
     name = "date"
@@ -58,7 +60,11 @@ class ClickDate(click.ParamType):
     help="Last date for which data should be analyzed",
     metavar="YYYY-MM-DD",
 )
-@click.option("--experiment_slug", "--experiment-slug", help="Normandy slug of the experiment to rerun analysis for")
+@click.option(
+    "--experiment_slug",
+    "--experiment-slug",
+    help="Normandy slug of the experiment to rerun analysis for",
+)
 @click.option("--dry_run/--no_dry_run", help="Don't publish any changes to BigQuery")
 def run(project_id, dataset_id, start_date, end_date, experiment_slug, dry_run):
     """Fetches experiments from Experimenter and runs analysis on active experiments."""

--- a/pensieve/experimenter.py
+++ b/pensieve/experimenter.py
@@ -61,6 +61,10 @@ class ExperimentCollection:
         cls = type(self)
         return cls([ex for ex in self.experiments if ex.type in type_or_types])
 
+    def with_slug(self, slug: str) -> "ExperimentCollection":
+        cls = type(self)
+        return cls([ex for ex in self.experiments if ex.slug == slug])
+
     def started_since(self, since: dt.datetime) -> "ExperimentCollection":
         """since should be a tz-aware datetime in UTC."""
         cls = type(self)

--- a/pensieve/tests/test_cli.py
+++ b/pensieve/tests/test_cli.py
@@ -1,0 +1,18 @@
+from datetime import date
+from pensieve import cli
+
+
+class TestCli:
+    def test_date_range(self):
+        start_date = date(2020, 5, 1)
+        end_date = date(2020, 5, 1)
+        date_range = list(cli.date_range(start_date, end_date))
+        assert len(date_range) == 1
+        assert date_range[0] == date(2020, 5, 1)
+
+        start_date = date(2020, 5, 1)
+        end_date = date(2020, 5, 5)
+        date_range = list(cli.date_range(start_date, end_date))
+        assert len(date_range) == 5
+        assert date_range[0] == date(2020, 5, 1)
+        assert date_range[4] == date(2020, 5, 5)

--- a/pensieve/tests/test_cli.py
+++ b/pensieve/tests/test_cli.py
@@ -3,16 +3,16 @@ from pensieve import cli
 
 
 class TestCli:
-    def test_date_range(self):
+    def test_inclusive_date_range(self):
         start_date = date(2020, 5, 1)
         end_date = date(2020, 5, 1)
-        date_range = list(cli.date_range(start_date, end_date))
+        date_range = list(cli.inclusive_date_range(start_date, end_date))
         assert len(date_range) == 1
         assert date_range[0] == date(2020, 5, 1)
 
         start_date = date(2020, 5, 1)
         end_date = date(2020, 5, 5)
-        date_range = list(cli.date_range(start_date, end_date))
+        date_range = list(cli.inclusive_date_range(start_date, end_date))
         assert len(date_range) == 5
         assert date_range[0] == date(2020, 5, 1)
         assert date_range[4] == date(2020, 5, 5)

--- a/pensieve/tests/test_experimenter.py
+++ b/pensieve/tests/test_experimenter.py
@@ -205,3 +205,9 @@ def test_normandy_experiment_slug(experiment_collection):
     assert "addon-activity-stream-search-topsites-release-69-1576277" in normandy_slugs
     assert None in normandy_slugs
     assert "pref-doh-us-engagement-study-v2-release-69-71-bug-1590831" in normandy_slugs
+
+
+def test_with_slug(experiment_collection):
+    experiments = experiment_collection.with_slug("search-topsites")
+    assert len(experiments.experiments) == 1
+    assert experiments.experiments[0].slug == "search-topsites"

--- a/pensieve/tests/test_experimenter.py
+++ b/pensieve/tests/test_experimenter.py
@@ -211,3 +211,6 @@ def test_with_slug(experiment_collection):
     experiments = experiment_collection.with_slug("search-topsites")
     assert len(experiments.experiments) == 1
     assert experiments.experiments[0].slug == "search-topsites"
+
+    experiments = experiment_collection.with_slug("non-existing-slug")
+    assert len(experiments.experiments) == 0


### PR DESCRIPTION
Addresses https://github.com/mozilla/pensieve/issues/59

I added some options to the CLI `run` command that allow to specify running the analysis only on a specific experiment and on a specific date range.  I also added a `rerun` option to re-run all analyses for a specific experiment starting at the experiment `start_date`.