### PR TITLE
Add a "enrollment" analysis window

### DIFF
--- a/pensieve/__init__.py
+++ b/pensieve/__init__.py
@@ -5,8 +5,9 @@ class AnalysisPeriod(enum.Enum):
     DAY = "day"
     WEEK = "week"
     OVERALL = "overall"
+    ENROLLMENT = "enrollment"  # The day of enrollment; useful for some messaging experiments
 
     @property
     def adjective(self) -> str:
-        d = {"day": "daily", "week": "weekly", "overall": "overall"}
-        return d[self.value]
+        d = {"day": "daily", "week": "weekly"}
+        return d.get(self.value, self.value)

--- a/pensieve/config.py
+++ b/pensieve/config.py
@@ -249,6 +249,7 @@ class MetricsSpec:
     daily: List[MetricReference] = attr.Factory(list)
     weekly: List[MetricReference] = attr.Factory(list)
     overall: List[MetricReference] = attr.Factory(list)
+    enrollment: List[MetricReference] = attr.Factory(list)
 
     definitions: Dict[str, MetricDefinition] = attr.Factory(dict)
 
@@ -303,6 +304,7 @@ class MetricsSpec:
         self.daily += other.daily
         self.weekly += other.weekly
         self.overall += other.overall
+        self.enrollment += other.enrollment
         self.definitions.update(other.definitions)
 
 

--- a/pensieve/tests/test_analysis.py
+++ b/pensieve/tests/test_analysis.py
@@ -20,10 +20,12 @@ def test_get_timelimits_if_ready(experiments):
     assert analysis._get_timelimits_if_ready(AnalysisPeriod.WEEK, date) is None
 
     date = dt.datetime(2019, 12, 1, tzinfo=pytz.utc) + timedelta(7)
+    assert analysis._get_timelimits_if_ready(AnalysisPeriod.ENROLLMENT, date)
     assert analysis._get_timelimits_if_ready(AnalysisPeriod.DAY, date)
     assert analysis._get_timelimits_if_ready(AnalysisPeriod.WEEK, date) is None
 
     date = dt.datetime(2019, 12, 1, tzinfo=pytz.utc) + timedelta(days=13)
+    assert analysis._get_timelimits_if_ready(AnalysisPeriod.ENROLLMENT, date) is None
     assert analysis._get_timelimits_if_ready(AnalysisPeriod.DAY, date)
     assert analysis._get_timelimits_if_ready(AnalysisPeriod.WEEK, date)
 


### PR DESCRIPTION
Right now, this corresponds to the first daily window, but it allows us to capture some messaging events (click-through rate, etc) that should happen on the day of enrollment.

It's possible we should actually wait "a few" days for this, since some impressions could happen at 23:59 and not get a response until the next day, etc. @SuYoungHong, do you have a sense of how long we should wait for a user to respond to e.g. a CFR impression?